### PR TITLE
[Client]: Send errors when success GraphQL request

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -80,6 +80,10 @@ function makeClient() {
 
                 if (response.status >= 200 && response.status < 300) {
                     const result = await response.json();
+                    
+                    if (result.errors) {
+                        return Promise.reject(result.errors);
+                    }
 
                     if (result.data) {
                         return result.data;


### PR DESCRIPTION
Otherwise, I'm getting "Unknown GraphQL error" now, although the error is defined in the `errors` key, even if there was a successful request (200).